### PR TITLE
Footer: change YouTube link

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -30,7 +30,7 @@
                             <ul class="links list-sitemap">
                                 <li><b><div class="sitemap-cat">Community</div></b></li>
                                 <li><a class="sitemap-sub" href="https://www.facebook.com/orangedm" target="_blank">Facebook</a></li>
-                                <li><a class="sitemap-sub" href="https://www.youtube.com/channel/UC_kfdmdWIQDRrsMpUMf_pmA" target="_blank">YouTube</a></li>
+                                <li><a class="sitemap-sub" href="https://www.youtube.com/channel/UClKKWBe2SCAEyv7ZNGhIe4g" target="_blank">YouTube</a></li>
                                 <li><a class="sitemap-sub" href="https://twitter.com/orangedataminer" target="_blank">Twitter</a></li>
                                 <li><a class="sitemap-sub" href="https://datascience.stackexchange.com/questions/tagged/orange" target="_blank">Stack Exchange</a></li>
                             </ul>


### PR DESCRIPTION
Footer linked to scOrange instead of core Orange channel. Link fixed.