### PR TITLE
Download layout: small fixes

### DIFF
--- a/layouts/download/list.html
+++ b/layouts/download/list.html
@@ -41,21 +41,22 @@
                         <h3><a id="pip"></a>Pip</h3>
                         <p>Orange can also be installed from the Python Package Index:</p>
                         <pre><code>pip install orange3</code></pre>
-                    </div>
-                    <div class="content">
-                        <h2>Installing add-ons</h2>
+
+                        <h3>Installing add-ons</h3>
                         <p>Additional features can be added to Orange by installing add-ons. You can find add-on manager in Options menu.</p>
                     </div>
+                </div>
             </div>
         </div>
 
-        <div id="mac" class=" mac download-os downloadsize">
-                 <div class="" >
-                   <div class="content">
+            <div id="mac" class=" mac download-os downloadsize">
+                <div class="" >
+                    <div class="content">
                         <h2>Download the latest version for Mac</h2>
                         <a id="recommended-download" onclick="mac()" style="margin-top: 10px" class="btn btn-warning big-button-base" href="https://service.biolab.si/download/orange?platform=mac">
                             Download Orange
                         </a>
+                        
                         <h3><a id="standalone"></a>Bundle</h3>
                         <a href="https://service.biolab.si/download/orange?platform=mac">Orange.dmg</a><br/>
                         <p>A universal bundle with everything packed in and ready to use.</p>
@@ -70,15 +71,13 @@
                         <h3><a id="pip"></a>Pip</h3>
                         <p>Orange can also be installed from the Python Package Index:</p>
                         <pre><code>pip install orange3</code></pre>
-                
-                 </div>
-                 <div class="content">
-                        <h2>Installing add-ons</h2>
+
+                        <h3>Installing add-ons</h3>
                         <p>Additional features can be added to Orange by installing add-ons. You can find add-on manager in Options menu.</p>
                     </div>
-
+                </div>
             </div>
-        </div>
+    
         <div id="lin" class=" mac download-os downloadsize">
                  <div class="" >
                    <div class="content">
@@ -98,7 +97,6 @@
                     <p>Orange can also be installed from the Python Package Index. You may need additional system packages provided by your distribution.</p>
                     <pre><code>pip install orange3</code></pre>
 
-
                     <h3>Installing from source</h3>
                     <p>Clone our repository from <a href="https://github.com/biolab/orange3">GitHub</a> or download
                         the <a href="https://github.com/biolab/orange3/archive/stable.tar.gz">source code tarball</a>.
@@ -106,16 +104,12 @@
                     </p>
                     <p>To run Orange Canvas run</p>
                     <pre><code>python -m Orange.canvas</code></pre>
-                
-                 </div>
-                 <div class="content">
-                        <h2>Installing add-ons</h2>
-                        <p>Additional features can be added to Orange by installing add-ons. You can find add-on manager in Options menu.</p>
-                    </div>
 
+                    <h3>Installing add-ons</h3>
+                    <p>Additional features can be added to Orange by installing add-ons. You can find add-on manager in Options menu.</p>
+                </div>
             </div>
         </div>
-    </div>
 
         </div>
         <script type="text/javascript">


### PR DESCRIPTION
Install add-ons section should be \<h2\> not a separate content. Also an empty line has to be visible after the final section (currently Linux subpage does not have it).