### PR TITLE
Remove deprecated installation guide

### DIFF
--- a/content/getting-started/download_install.md
+++ b/content/getting-started/download_install.md
@@ -9,4 +9,4 @@ buttonText = "Download Orange"
 +++
 
 
-Download Orange distribution package and run the installation file on your local computer. {{< link_new url="http://biolab.github.io/datafusion-installation-guide/" name="Here">}} is a step-by-step installation guide, that we recommend you to follow.
+Download Orange distribution package and run the installation file on your local computer. Follow installation guides for your operating system.


### PR DESCRIPTION
Reference to the step-by-step installation guide was extremely deprecated so it is better to remove it.