### PR TITLE
[FIX] Download page alignment

### DIFF
--- a/layouts/download/list.html
+++ b/layouts/download/list.html
@@ -1,11 +1,11 @@
 {{ define "main"}}
 
 <section id="features" class="features section downloads ">
-        <div class="container-fluid downloados downloadsize" style="margin-top: 50px;">
+        <div class="container downloados" style="margin-top: 50px;">
             <div class="row" style="padding: 0px !important;text-align: center;">
                 <div class="dow" style="display: inline-block; width: 80%;">
                     {{ range .Site.Data.tabs}}
-                    <div class="icon-item col-xl-4 col-lg-4 col-md-4 col-sm-4  col-xs-4 text-center" >
+                    <div class="icon-item col-xl-4 col-lg-4 col-md-4 col-sm-4  col-xs-14 text-center" >
                         <a onclick="windows({{.os}})" href="#{{.os}}">
                             <div id="{{.os}}1" class="icon">
                                 <i class="fa fa-{{ .icon }} jsonly icon-button"></i>
@@ -18,9 +18,9 @@
             </div><!--//row-->
         </div><!--//container-->
 
-        <div class="container-fluid" style="padding-bottom: 40px;">
+        <div class="container" style="padding-bottom: 40px;">
             <div class="row col">
-            <div id="win" class=" download-os downloadsize">
+            <div id="win" class=" download-os">
                 <div class="">
                     <div class="content">
                         <h2>Download the latest version for Windows</h2>
@@ -49,7 +49,7 @@
             </div>
         </div>
 
-            <div id="mac" class=" mac download-os downloadsize">
+            <div id="mac" class=" mac download-os">
                 <div class="" >
                     <div class="content">
                         <h2>Download the latest version for Mac</h2>
@@ -78,7 +78,7 @@
                 </div>
             </div>
     
-        <div id="lin" class=" mac download-os downloadsize">
+        <div id="lin" class=" mac download-os">
                  <div class="" >
                    <div class="content">
                     <h2>Linux / Source</h2>

--- a/layouts/download/list.html
+++ b/layouts/download/list.html
@@ -5,7 +5,7 @@
             <div class="row" style="padding: 0px !important;text-align: center;">
                 <div class="dow" style="display: inline-block; width: 80%;">
                     {{ range .Site.Data.tabs}}
-                    <div class="icon-item col-xl-4 col-lg-4 col-md-4 col-sm-4  col-xs-14 text-center" >
+                    <div class="icon-item col-xl-4 col-lg-4 col-md-4 col-sm-4 col-xs-4 text-center" >
                         <a onclick="windows({{.os}})" href="#{{.os}}">
                             <div id="{{.os}}1" class="icon">
                                 <i class="fa fa-{{ .icon }} jsonly icon-button"></i>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,6 +1,6 @@
 <footer class="footer">
         <div class="container">
-            <div class="row footer-pad">
+            <div class="row">
 
                 <div class="col-md-4 col-sm-6 col-xs-12">
                     <div class="row">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
  <header id="top" class="header navbar-fixed-top">
-        <div class="container header-pad" >
+        <div class="container" >
             <h1 class="logo pull-left" >
                 <a id="header-orangelogo" href="/">
                     <img id="logo-image" class="logo-image" src="/images/orange_logo_new.png" alt="Logo">

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -30,10 +30,12 @@ a:hover {
   text-decoration: none;
   color: #f69111;
 }
+
 .container{
   padding-left: 0px;
   padding-right: 0px;
 }
+
 .btn {
   -webkit-transition: all 0.2s ease-in-out;
   -moz-transition: all 0.2s ease-in-out;
@@ -951,9 +953,9 @@ svg{
   /*.container{
     padding: 0px !important;
   }*/
-  .header-pad{
+  /* .header-pad{
     padding-left: 5% !important;
-  }
+  } */
   .intro{
     padding: 0px !important;
     padding-left: 5% !important;
@@ -1069,6 +1071,13 @@ svg{
   .downloadsize{
     padding-left:8%;
     padding-right:8%;
+  }
+}
+
+  @media (max-width: 768px) {
+  .container {
+    padding-left: 15px;
+    padding-right: 15px;
   }
 }
 
@@ -1338,10 +1347,6 @@ h2.docs-subtitle {
   margin-left: 0px !important;
 }
 
-#features .row{
-  margin-right:0px !important;
-  margin-left: 0px !important;
-}
 
 .blog-content{
   padding-top: 20px !important;
@@ -1407,10 +1412,6 @@ padding-top: 10px;
   margin-left: 0px !important;
 }
 
-#features .row{
-  margin-right:0px !important;
-  margin-left: 0px !important;
-}
 
 @media (max-width: 768px) {
   .feature-title, .promo .row h1.firstpagetitle {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1485,7 +1485,7 @@ margin-top: auto;
   .dow {
     width: 100% !important;  
   }
-  .col-xs-4 {
+  .dow > .col-xs-4 {
     padding-left: 0px;
     padding-right: 0px;
   }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1481,13 +1481,16 @@ margin-top: auto;
   padding: 0 10px 10px 0;
 }
 
-@media (max-width: 844px) {
-  .dow{
-    width: 100% !important;
-    padding-left: 20px;
-    padding-right: 20px
+@media (max-width: 600px) {
+  .dow {
+    width: 100% !important;  
+  }
+  .col-xs-4 {
+    padding-left: 0px;
+    padding-right: 0px;
   }
 }
+
 .entry-title {
     font-size: 30px !important;
     font-weight: normal !important;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -948,14 +948,8 @@ svg{
 
   .text-workflow{
     padding-top: 0px !important;
-  }
-  
-  /*.container{
-    padding: 0px !important;
-  }*/
-  /* .header-pad{
-    padding-left: 5% !important;
-  } */
+  } 
+
   .intro{
     padding: 0px !important;
     padding-left: 5% !important;


### PR DESCRIPTION
-Content is now left-aligned with navigation bar logo. 

-Fixes navigation bar logo magical inward jumping, when screen size is changed. 

-OS icons are now vertically aligned on small screen sizes. 

Fixes #70

