### PR TITLE
download: Show popup only once

### DIFF
--- a/layouts/download/list.html
+++ b/layouts/download/list.html
@@ -277,7 +277,13 @@
         document.getElementById("recommended-download-win").addEventListener("click", openPopup);
         document.getElementById("recommended-download-mac").addEventListener("click", openPopup);
 
+        var popupShown = false;
         function openPopup() {
+            if(popupShown) {
+                return;
+            }
+            popupShown = true;
+
             window.setTimeout(() => {
                 popup.style.display = "block";
             }, 2000);


### PR DESCRIPTION
Instead of showing the popup upon each click on download, show it only once (until the page is reloaded).