### PR TITLE
support statement in doc page

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -4,3 +4,4 @@ url = "/docs"
 listing = true
 +++
 
+For a list of frequently asked questions, see [FAQ](/faq/). Also, feel free to reach out to us in our [Discord chatroom](https://discord.gg/FWrfeXV).

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -13,9 +13,10 @@
                             {{ .Content }}
                         </div>
                     {{ end }}
-
                     </div>
             </div>
+            <h1 class="title">Support</h1>
+            <div style="text-align:center;padding-bottom: 30px">{{ .Content }}</div>
         </div>
     </div>
 


### PR DESCRIPTION
A short section on support was added to the list of documentation pages. We would like to expose the Discord support channel and an FAQ list that were otherwise visible only to those that clicked on the "Contact" page at the footer of the web page.