### PR TITLE
Prepare Orange release 2.4.1

### DIFF
--- a/layouts/download/list.html
+++ b/layouts/download/list.html
@@ -41,13 +41,13 @@
                 <div class="content">
                     <h2>Download the latest version for Windows</h2>
                     <a id="recommended-download-win" style="margin-top: 10px" class="btn btn-warning big-button-base"
-                        href="https://service.biolab.si/download/orange?platform=win">
+                        href="https://download.biolab.si/download/files/Orange3-3.24.1-Miniconda-x86_64.exe">
                         Download Orange
                     </a>
 
                     <h3><a id="standalone"></a>Standalone installer (default)</h3>
                     <a id="recommended-download"
-                        href="https://service.biolab.si/download/orange?platform=win">Orange3-Miniconda-x86_64.exe
+                        href="https://download.biolab.si/download/files/Orange3-3.24.1-Miniconda-x86_64.exe">Orange3-Miniconda-x86_64.exe
                         (64 bit)</a><br />
                     <p>Can be used without administrative priviledges.</p>
                     <h3><a id="anaconda"></a>Anaconda</h3>
@@ -80,13 +80,13 @@
                 <div class="content">
                     <h2>Download the latest version for Mac</h2>
                     <a id="recommended-download-mac" style="margin-top: 10px" class="btn btn-warning big-button-base"
-                        href="https://service.biolab.si/download/orange?platform=mac">
+                        href="https://download.biolab.si/download/files/Orange3-3.24.1.dmg">
                         Download Orange
                     </a>
 
                     <h3><a id="standalone"></a>Bundle</h3>
                     <a id="recommended-download"
-                        href="https://service.biolab.si/download/orange?platform=mac">Orange.dmg</a><br />
+                        href="https://download.biolab.si/download/files/Orange3-3.24.1.dmg">Orange.dmg</a><br />
                     <p>A universal bundle with everything packed in and ready to use.</p>
 
                     <h3><a id="anaconda"></a>Anaconda</h3>


### PR DESCRIPTION
Release links are updated to bypass our service. This increases stability, but the links need to be updated at each release.