### PR TITLE
docs: change Tutorial and Reference links

### DIFF
--- a/content/docs/python_library.md
+++ b/content/docs/python_library.md
@@ -4,6 +4,6 @@ weight = -100
 image = "/images/orange_docs_03_small.png"
 +++
 
-[Tutorial](http://docs.orange.biolab.si/3/data-mining-library/#tutorial)
-[Reference](http://docs.orange.biolab.si/3/data-mining-library/#reference)
+[Tutorial](https://orange-data-mining-library.readthedocs.io/en/latest/#tutorial)
+[Reference](https://orange-data-mining-library.readthedocs.io/en/latest/#reference)
 [Orange 2.7 documentation](http://docs.orange.biolab.si/2)


### PR DESCRIPTION
Is there a reason that we still use http://docs.orange.biolab.si/3/?