### PR TITLE
Add global variable for Orange version.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,8 @@ languageCode = "en-us"
 paginate = 10 #frontpage pagination
 title = "Orange"
 disqusShortname = "orange-4"
+[params]
+  version = "3.24.1"
 
 [outputFormats]
   [outputFormats.workflow]

--- a/layouts/download/list.html
+++ b/layouts/download/list.html
@@ -41,13 +41,13 @@
                 <div class="content">
                     <h2>Download the latest version for Windows</h2>
                     <a id="recommended-download-win" style="margin-top: 10px" class="btn btn-warning big-button-base"
-                        href="https://download.biolab.si/download/files/Orange3-3.24.1-Miniconda-x86_64.exe">
-                        Download Orange
+                        href="https://download.biolab.si/download/files/Orange3-{{$.Site.Params.version}}-Miniconda-x86_64.exe">
+                        Download Orange {{$.Site.Params.version}}
                     </a>
 
                     <h3><a id="standalone"></a>Standalone installer (default)</h3>
                     <a id="recommended-download"
-                        href="https://download.biolab.si/download/files/Orange3-3.24.1-Miniconda-x86_64.exe">Orange3-Miniconda-x86_64.exe
+                        href="https://download.biolab.si/download/files/Orange3-{{$.Site.Params.version}}-Miniconda-x86_64.exe">Orange3-Miniconda-x86_64.exe
                         (64 bit)</a><br />
                     <p>Can be used without administrative priviledges.</p>
                     <h3><a id="anaconda"></a>Anaconda</h3>
@@ -80,13 +80,13 @@
                 <div class="content">
                     <h2>Download the latest version for Mac</h2>
                     <a id="recommended-download-mac" style="margin-top: 10px" class="btn btn-warning big-button-base"
-                        href="https://download.biolab.si/download/files/Orange3-3.24.1.dmg">
-                        Download Orange
+                        href="https://download.biolab.si/download/files/Orange3-{{$.Site.Params.version}}.dmg">
+                        Download Orange {{$.Site.Params.version}}
                     </a>
 
                     <h3><a id="standalone"></a>Bundle</h3>
                     <a id="recommended-download"
-                        href="https://download.biolab.si/download/files/Orange3-3.24.1.dmg">Orange.dmg</a><br />
+                        href="https://download.biolab.si/download/files/Orange3-{{$.Site.Params.version}}.dmg">Orange.dmg</a><br />
                     <p>A universal bundle with everything packed in and ready to use.</p>
 
                     <h3><a id="anaconda"></a>Anaconda</h3>
@@ -164,12 +164,12 @@
             } catch (err) {
                 versions = null
             }
-            if (versions != null) {
-                var win = document.getElementById("recommended-download-win");
-                win.textContent += versions.win;
-                var mac = document.getElementById("recommended-download-mac");
-                mac.textContent += versions.mac;
-            }
+            // if (versions != null) {
+            //     var win = document.getElementById("recommended-download-win");
+            //     win.textContent += versions.win;
+            //     var mac = document.getElementById("recommended-download-mac");
+            //     mac.textContent += versions.mac;
+            // }
         }
         hash = window.location.hash.substr(1);
 


### PR DESCRIPTION
Add variable `version`  in `config.toml` for download page. Every time te version updates, we need to change the version of the Orange in `config.toml`, so that the new version is visible and available on the Orange website. 