### PR TITLE
covid-19: Ungracefully add some meta tags for Facebook

### DIFF
--- a/content/blog/2020/2020-04-02-covid-19-basic.md
+++ b/content/blog/2020/2020-04-02-covid-19-basic.md
@@ -10,6 +10,9 @@ categories = ["covid-19", "feature construction", "line plot"]
 shortExcerpt = "Basic tricks for loading and analysing Covid-19 data."
 longExcerpt = "Basic tricks for loading and analysing Covid-19 data."
 +++
+<meta property="og:title" content="Data Mining Covid-19 Epidemics: Part 1">
+<meta property="og:description" content="Orange Interactive Data Mining Toolbox">
+<meta property="og:image" content="https://orange.biolab.si/blog_img/2020/2020-04-02-europe-scatter-line-plot.png">
 
 These days we are all following the statistics of COVID-19, looking at how our own country is faring and how it's comparing with other countries. Luckily, only a few have a statistically meaningful number of deaths (which solemnly reminds us of the difference between statistical and practical significance!), so we concentrate on the number of confirmed cases.
 


### PR DESCRIPTION
Facebook isn't the best at picking thumbnails. 

Even though the meta tags are outside of <head>, this should work. We should consider setting these for all blog posts (in <head> somehow, leveraging hugo).