### PR TITLE
Prevent hugo to automatically convert page links to lowercase

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,8 @@ languageCode = "en-us"
 paginate = 10 #frontpage pagination
 title = "Orange"
 disqusShortname = "orange-4"
+disablePathToLower = "True"
+
 [params]
   version = "3.25.0"
 


### PR DESCRIPTION
This stopped at least PCA and DBSCAN docs from working. I checked
all files in content/ for uppercase characters. Did not find any and
therefore it seems that this will not break any other pages.

Connected hugo issue (from 2015):
https://github.com/gohugoio/hugo/issues/557

Fixes biolab/orange3#4702