### PR TITLE
Fix PyQt error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ addons:
     packages:
       - python-pygments
       - libxkbcommon-x11-0  # for PyQt 5.12
+      - libxcb-icccm4
+      - libxcb-image0
+      - libxcb-keysyms1
+      - libxcb-randr0
+      - libxcb-render-util0
+      - libxcb-xinerama0
 
 install:
     - wget https://github.com/gohugoio/hugo/releases/download/v0.49.2/hugo_0.49.2_Linux-64bit.deb


### PR DESCRIPTION
PyQt==5.15.* needs additional packages to run successfully. With this PR I added missing packages.