### PR TITLE
Rename screenshot classes, render downscaled images nicer

### DIFF
--- a/content/blog/2020/2020-04-02-covid-19-basic.md
+++ b/content/blog/2020/2020-04-02-covid-19-basic.md
@@ -26,9 +26,9 @@ https://github.com/CSSEGISandData/COVID-19/blob/master/csse_covid_19_data/csse_c
 
 To get the numbers behind the above table, click "Raw". Or this link: [https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_global.csv](https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_global.csv). Save the page and you'll have a file to play with.
 
-{{% sidework src="/blog_img/2020/2020-04-02-workflow-01-01.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-02-workflow-01-01.png" %}}
 Easier still, Orange's File widget can load the data directly from the web, and handles a basic .csv file (for more fine-grained options, use CSV File Import). 
-{{% tooltippic src="/blog_img/2020/2020-04-02-file-widget.png" %}}
+{{% window-screenshot src="/blog_img/2020/2020-04-02-file-widget.png" %}}
 So, for starters, add the File widget to the canvas and copy the above link to the URL field. You can then connect it to a Data Table widget and check that everything's loaded OK. You should see a table with rows corresponding to regions and countries, and columns corresponding to dates, with two additional columns detailing region locations (latitude, longitude).
 
 
@@ -36,31 +36,31 @@ Note that this is live data, so your results will differ from those we show here
 
 ## Plot the usual plots
 
-{{% sidework src="/blog_img/2020/2020-04-02-workflow-01-02.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-02-workflow-01-02.png" %}}
 Connect the File to a Line Plot widget to see the graph. By default, Line Plot shows means and ranges, while we are interested in raw lines. Let's click the checkboxes accordingly.
 
 {{% figure src="/blog_img/2020/2020-04-02-lineplot.png" %}}
 
 Pretty boring. Anybody can do this in Excel. Orange allows us to play with these curves, though.
 
-{{% tooltippic src="/blog_img/2020/2020-04-02-select-line.gif" %}}
+{{% window-screenshot src="/blog_img/2020/2020-04-02-select-line.gif" %}}
 The curve that grows rapidly but then flattens out -- is probably China, right? To check this, select it. It may be hard to click the curve, so select it by dragging a line across it. 
 
-{{% sidework src="/blog_img/2020/2020-04-02-workflow-01-03.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-02-workflow-01-03.png" %}}
 Then, connect the Line Plot widget to Data Table, and it will show the data for this curve. You'll learn that this is, of course, the Hubei province – where it all started.
 
-{{% tooltippic src="/blog_img/2020/2020-04-02-steep-curves.png" %}}
+{{% window-screenshot src="/blog_img/2020/2020-04-02-steep-curves.png" %}}
 What are the fast-rising curves? Select them by dragging a line across them, and check the Data Table widget: these are the US, Iran, Italy, Spain, Germany and France.
 
-{{% sidework src="/blog_img/2020/2020-04-02-workflow-01-04.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-02-workflow-01-04.png" %}}
 We can do it the other way around: connect File to Data Table and Data Table to Line Plot, such that the Data Table sends its selected subset of data.
 
-{{% tooltippic src="/blog_img/2020/2020-04-02-select-country.png" %}}
+{{% window-screenshot src="/blog_img/2020/2020-04-02-select-country.png" %}}
 In the Data Table, you can now find and click your favourite country. Line Plot will now highlight the curve for Slovenia (or whichever country you chose). You can also select multiple countries, like all the Chinese provinces. Or all European countries.
 
 Well, the latter is a bit difficult; there is no data about the continent. There's a trick, though. 
 
-{{% sidework src="/blog_img/2020/2020-04-02-workflow-01-05.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-02-workflow-01-05.png" %}}
 Replace the Data Table widget with a Scatter Plot widget, and choose Long and Lat for x and y respectively. Zoom in on Europe and select the points by dragging across them. Line Plot will highlight the curves belonging to the countries chosen in the Scatter Plot.
 {{% figure src="/blog_img/2020/2020-04-02-europe-scatter-line-plot.png" %}}
 
@@ -73,39 +73,39 @@ The message here regards the essential difference between plotting curves and re
 Let's solve the problem of negligible curves for small countries. This is not just about populations: the biggest problem is that confirmed cases are the result of testing, and testing strategies vary by country. Icelanders and Koreans test like crazy, while the number of tests in the US was (initially) so small it was comparable to that of Slovenia (and with it, the number of confirmed cases). The number of tests could thus **normalize** the number of confirmed cases, but this wouldn't do either; the testing isn't equivalent – some countries test more at random, while others save tests for groups at greater risk. And regardless, exact data about the number of tests is not readily available.
 
 So, let's fallback to the number of cases per million inhabitants. Neither this nor the population of countries are present in the data provided by John Hopkins University. We do, however, have another data set at arm's reach: the population of countries (for year 2015) appears in the Worldbank's Human development index (HDI) data. 
-{{% sidework src="/blog_img/2020/2020-04-02-workflow-02-01.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-02-workflow-02-01.png" %}}
 To load it, use the Datasets widget, find and double-click the HDI data set.
-{{% tooltippic src="/blog_img/2020/2020-04-02-merge-data.png" %}}
+{{% window-screenshot src="/blog_img/2020/2020-04-02-merge-data.png" %}}
 Now we're working with two data sets. 
-{{% sidework src="/blog_img/2020/2020-04-02-workflow-02-02.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-02-workflow-02-02.png" %}}
 Let's merge them using the Merge Data widget: connect both the File widget (with the John Hopkins data), and the Datasets widget (with the HDI data) to Merge Data. Make sure to match the "Country/Region" feature in COVID-19 data with the "Country" feature in HDI. It is also important to connect the widgets in this order, so File provides the main data and the Datasets widget augments it with additional annotation columns. If you do it incorrectly, double-click the connections to fix it.
 
 The match is imperfect: some countries appear with different names, for instance, "*Russia*" from John Hopkins doesn't match the "*Russian Federation*" from HDI, and the John Hopkin's "*US*" and doesn't match HDI's "*United States*". 
 
 The population of Liechtenstein in millions with one decimal is 0.0; similar for Palau. 
-{{% sidework src="/blog_img/2020/2020-04-02-workflow-02-03.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-02-workflow-02-03.png" %}}
 To remove countries with unknown or zero population, we continue with Select Rows, where we set the condition "Total Population (millions) 2015 is greater than 0".
-{{% tooltippic src="/blog_img/2020/2020-04-02-select-rows.png" %}}
+{{% window-screenshot src="/blog_img/2020/2020-04-02-select-rows.png" %}}
 
 Now for some constructive business. 
-{{% sidework src="/blog_img/2020/2020-04-02-workflow-02-04.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-02-workflow-02-04.png" %}}
 To get the number of cases on some particular day, we use the Feature Constructor widget, where we can input a formula to compute new data columns. In "New" we select Numeric, type `cases per million` as the name of the new column, Select Feature "3_29_20" (or whichever date we'd like), add `/`, and then select "Total_Population\_\_millions\_\_2015". 
 As a shortcut, you can just copy `_3_29_20 / Total_Population__millions__2015` into the "Expression..." line. (Note that an underscore precedes `3_29_20`: this way Orange knows that this is not a number but a name of a column.)
 
 {{% figure src="/blog_img/2020/2020-04-02-construct-features.png" %}}
 
 Things got crowded, so perhaps we can remove some columns. 
-{{% sidework src="/blog_img/2020/2020-04-02-workflow-02-05.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-02-workflow-02-05.png" %}}
 We add Select Columns, open it, and remove all columns we don't need right now. We can just select all features (Ctrl-A or Cmd-A) and drag them to the left, and then drag "cases per million" back to features.
-{{% tooltippic src="/blog_img/2020/2020-04-02-select-columns.png" %}}
+{{% window-screenshot src="/blog_img/2020/2020-04-02-select-columns.png" %}}
 
 Finally, add and connect a Data Table.
 
-{{% sidework src="/blog_img/2020/2020-04-02-workflow-1-day.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-02-workflow-1-day.png" %}}
 
 Sort by the last column and, voilá, you've ranked countries the number of cases per a million inhabitants.
 
-{{% tooltippic src="/blog_img/2020/2020-04-02-1-day-table.png" %}}
+{{% window-screenshot src="/blog_img/2020/2020-04-02-1-day-table.png" %}}
 
 Missing in action: China. The data for China is split into provinces, yet every row is divided by the country's entire population. France seems to have a similar problem: it is given as a single country, but followed by external territories whose numbers are divided by the entire population. Also missing in action: Russia / Russian Federation, and US / United States, as we've previously explained.
 
@@ -137,7 +137,7 @@ Now that I've taught you how to fish, I give you a fish for today: after editing
 
 Comparing this data with the World Bank's data is great because it allows us to relate the epidemiological data to data about particular countries.
 
-{{% sidework src="/blog_img/2020/2020-04-02-workflow-02-07.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-02-workflow-02-07.png" %}}
 In Select Columns, we removed most of the features. Bring back all those that come from HDI. Now connect, say, a Scatter Plot and observe the relation between the number of cases per million and the number of physicians per ten thousand, which is the closest approximation to the capabilities of health systems.
 
 {{% figure src="/blog_img/2020/2020-04-02-scatter-physicians.png" %}}
@@ -176,7 +176,7 @@ out_data = Orange.data.Table.from_numpy(
     normalized, in_data.Y, in_data.metas)
 ```
 
-{{% tooltippic src="/blog_img/2020/2020-04-02-python-script.png" %}} 
+{{% window-screenshot src="/blog_img/2020/2020-04-02-python-script.png" %}} 
 With `in_data[:, "Total Population (millions) 2015"]` we take the table corresponding to the column with the population. Since population is now a meta attribute, we take `.metas`. We divide `in_data.X` with this column. Finally, we construct a new table named `out_data`, with the same domain (that is, the same variables), the normalized data, and the original data for target variable(s) and metas.
 
 We get a similar line plot as before, just with proper scale. Observe it. There are two countries with 3000-4000 confirmed cases per million?! Which? Check yourself!

--- a/content/blog/2020/2020-04-09-covid-19-part-2.md
+++ b/content/blog/2020/2020-04-09-covid-19-part-2.md
@@ -33,7 +33,7 @@ You should already be familiar with the Scatter Plot widget. In the previous blo
 
 A better solution is to use Geo Map from the Orange3-Geo add-on. It provides a variety of maps as backgrounds. With them, it's much easier to associate points with locations. To start, first load the [COVID-19 data set](https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_global.csv) using the File widget, [as shown in the previous post](https://orange.biolab.si/blog/2020/2020-04-02-covid-19-basic/). Then, add and connect a Geo Map widget. 
 
-{{% sidework src="/blog_img/2020/2020-04-09-workflow-01.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-09-workflow-01.png" %}}
 
 Latitude and longitude are automatically selected. Below, you can define similar point properties, as in the scatter plot. The size of a point can intuitively represent the number of cases, so let's select the latest date in the *Size* dropdown. If you're feeling adventurous, try changing the map type to satellite or topological.
 
@@ -47,7 +47,7 @@ Just like in Scatter Plot, you can scroll to zoom in and out, and click/drag to 
 
 The map is nice and informative, and it's easy to distinguish larger epidemics from smaller ones. Still, those similarly-sized points on the map represent entire countries from big Russia to small Slovenia. We could, alternatively, represent countries by coloring their surface area. This is a job for Choropleth Map. Let's add it and connect it.
 
-{{% sidework src="/blog_img/2020/2020-04-09-workflow-02.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-09-workflow-02.png" %}}
 
 This widget is similar to Geo Map, but instead of displaying data as points, it aggregates them into regions (e.g., Country, State, Province), and displays those instead. Under *Attribute*, select the latest date and under *Agg.*, select *sum*. The colored regions now show the sum of confirmed COVID-19 cases for each country. 
 
@@ -67,15 +67,15 @@ We'll be using a special widget from Orange3-Timeseries: Time Slice, which lets 
 
 Time Slice requires time instances in the form of rows, while our data specifies them in columns. Let's start again with the File widget that loads the data. Move *Lat* and *Long* to meta attributes by double-clicking  *feature* in the *Role* column and selecting *meta*. This will tell Orange to exclude them from data manipulations.
 
-{{% tooltippic src="/blog_img/2020/2020-04-09-file.gif" %}}
+{{% window-screenshot src="/blog_img/2020/2020-04-09-file.gif" %}}
 
 To flip rows and columns, we use the Transpose widget. Connect it to the File widget.
 
-{{% sidework src="/blog_img/2020/2020-04-09-workflow-03.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-09-workflow-03.png" %}}
 
 Set *From variable* to *Country/Region*. Ignore the warning that indices were added to variables with the same name; it won't hurt us.
 
-{{% tooltippic src="/blog_img/2020/2020-04-09-transpose-1.png" %}}
+{{% window-screenshot src="/blog_img/2020/2020-04-09-transpose-1.png" %}}
 
 To better understand what just happened, connect a Data Table to Transpose and see the result: rows and columns were swapped. Columns are named after countries (because we chose *Country/Region* in the Transpose widget), while a new column, *Feature name*, contains the original names of the columns.
 
@@ -83,17 +83,17 @@ To better understand what just happened, connect a Data Table to Transpose and s
 
 Right now, Orange is treating values in *Feature name* as strings. We need to tell Orange that the feature contains timestamps. Let's connect an Edit Domain widget. 
 
-{{% sidework src="/blog_img/2020/2020-04-09-workflow-04.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-09-workflow-04.png" %}}
 
 Scroll to the bottom of *Variables* and select *Feature name*. In *Edit*, change its type to *Time*. While you're at it, change its name to something meaningful, like *date*. Finally, click *Apply*
 
-{{% tooltippic src="/blog_img/2020/2020-04-09-edit-domain.gif" %}}
+{{% window-screenshot src="/blog_img/2020/2020-04-09-edit-domain.gif" %}}
 
 The data is now ready to be processed by Time Slice. 
 
-{{% sidework src="/blog_img/2020/2020-04-09-workflow-05.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-09-workflow-05.png" %}}
 
-{{% tooltippic src="/blog_img/2020/2020-04-09-time-slice.png" %}}
+{{% window-screenshot src="/blog_img/2020/2020-04-09-time-slice.png" %}}
 
 The top indicates the currently selected slice of data. You can change the interval by interacting with the histogram, or by adjusting the start and end dates directly below. Let's select a day's slice between the 25th and 26th January 2020. 
 
@@ -103,11 +103,11 @@ With a click of the play button, the slice moves, and the data output updates ac
 
 Make sure to stop the Time Slice playback before proceeding. We're almost at the finish line; we just need to transform the data back into its original form. To do so, connect another Transpose widget.
 
-{{% sidework src="/blog_img/2020/2020-04-09-workflow-06.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-09-workflow-06.png" %}}
 
 Under *Future names* select *Generic*, which will name the new column *Feature 1*.
 
-{{% tooltippic src="/blog_img/2020/2020-04-09-transpose-2.png" %}}
+{{% window-screenshot src="/blog_img/2020/2020-04-09-transpose-2.png" %}}
 
 Let's connect a Data Table for a final check of our data before putting it on a map.
 
@@ -117,7 +117,7 @@ Looking good!
 
 The final step entails connecting the Choropleth Map, selecting *Feature 1* as *Attribute*, and *Sum* as the *Agg*.
 
-{{% sidework src="/blog_img/2020/2020-04-09-workflow-07.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-09-workflow-07.png" %}}
 
 To observe the animation, open up both Choropleth and Time Slice at the same time.<br> 
 Protip: pressing Ctrl/CMD+Up reveals the workflow, Ctrl/CMD+Down reveals widget windows. 
@@ -128,15 +128,15 @@ All that's left is to hit play.
 
 Now that we're familiar with Time Slice, let's use it with Geo Map too. For bonus points, let's also remove countries with zero confirmed cases. That way, the number of points on the map will increase as the virus spreads throughout the world. For this, we'll use a Select Rows widget.
 
-{{% sidework src="/blog_img/2020/2020-04-09-workflow-08.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-09-workflow-08.png" %}}
 
 Under Conditions, select *Feature 1*, select *is greater than*, and type in *0*.
 
-{{% tooltippic src="/blog_img/2020/2020-04-09-select-rows.gif" %}}
+{{% window-screenshot src="/blog_img/2020/2020-04-09-select-rows.gif" %}}
 
 Add and connect a Geo Map widget. Zoom out, so you see the whole world, and on the left side, check *Freeze map*. This will prevented the map from jumping around as new points are added.
 
-{{% sidework src="/blog_img/2020/2020-04-09-workflow-09.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-09-workflow-09.png" %}}
 
 Press play once again – let's see what we've built!
 

--- a/content/blog/2020/2020-4-015-covid-19-part-3.md
+++ b/content/blog/2020/2020-4-015-covid-19-part-3.md
@@ -24,11 +24,11 @@ The spread of the virus is influenced by many factors, time being one of them. T
 
 We'll load our data as usual with the File widget. The data contains latitude and longitude columns, which are just getting in the way in our further analysis. We will use Select Columns to put them into meta columns and thus exclude them from any calculations. Then we'll select some countries we are interested in with the help of the Data Table. You could also do it straight after inspecting the data in Geo Map.
 
-{{% sidework src="/blog_img/2020/2020-04-15-wf1.png" %}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-15-wf1.png" %}}
 
 Now we just need to tell Orange, which variable contains time stamps. Our dates are represented as columns instead of as rows, so we'll use Transpose widget to make each row represent a datum and then connect it to As Timeseries Widget. In Transpose, we set the variable whose values will be used to name the rows when they are turned into columns. We'll name them by the column Country, as shown in the image, since the Province field is mostly empty. In As Timeseries, we set *sequence as implied by instance order*.
 
-{{% tooltippic src="/blog_img/2020/2020-04-15-as_timeseries.png" %}}
+{{% window-screenshot src="/blog_img/2020/2020-04-15-as_timeseries.png" %}}
 
 Here is our chain of widgets. We should now be ready to start making some plots. Phew.
 
@@ -74,7 +74,7 @@ Look at the aligned curves now, they are much easier to compare.
 
 Let's take a look at how fast the confirmed cases are spreading. Connect As Timeseries with Difference widget, choose Differencing and select countries of interest. Differencing order of 1 means we'll be looking at derivative of first order, which just means daily change in our case. We'll leave shift as is, on 1.
 
-{{% tooltippic src="/blog_img/2020/2020-04-15-diff-settings.png"%}}
+{{% window-screenshot src="/blog_img/2020/2020-04-15-diff-settings.png"%}}
 
 Again, we'll view the transformed curves in Line Chart. Notice how the difference (and every other) transform adds a new column? That means we can compare our curves in different states, so be sure to always check what is being shown. For starters, try looking at, for example, China and its transformed version. See how easy it is to spot the daily spikes that are perhaps out of the ordinary and need to be checked? The most prominent spike here is probably due to the change in counting.
 
@@ -90,7 +90,7 @@ The difference could be only due to the difference in population and what is an 
 
 Difference widget also has the option to output the quotients. It will allow us to observe the relative growth and compare countries directly.
 
-{{% tooltippic src="/blog_img/2020/2020-04-15-quot-settings.png"%}}
+{{% window-screenshot src="/blog_img/2020/2020-04-15-quot-settings.png"%}}
 
 Let's look at, for example, China (Hubei province) vs France.
 
@@ -102,9 +102,9 @@ It seems China is doing worse in the beginning and better later on, but it is im
 
 Smoothing is usually a part of preprocessing, so insert the Moving Transform widget between As Timeseries and Difference, and add some moving average transforms, like this:
 
-{{% sidework src="/blog_img/2020/2020-04-15-wf3.png"%}}
+{{% workflow-screenshot src="/blog_img/2020/2020-04-15-wf3.png"%}}
 
-{{% tooltippic src="/blog_img/2020/2020-04-15-mt-settings.png"%}}
+{{% window-screenshot src="/blog_img/2020/2020-04-15-mt-settings.png"%}}
 
 Selecting now smoothened China and the France data in Difference widget, yields the following plot in Line Chart:
 

--- a/layouts/shortcodes/tooltippic.html
+++ b/layouts/shortcodes/tooltippic.html
@@ -1,4 +1,0 @@
-<a href="{{ .Get `src`}}" class="blog-image_"> 
-      <img src="{{ .Get `src` }}" class="tooltippic" />
- </a>
-

--- a/layouts/shortcodes/window-screenshot.html
+++ b/layouts/shortcodes/window-screenshot.html
@@ -1,0 +1,4 @@
+<a href="{{ .Get `src`}}" class="blog-image_"> 
+      <img src="{{ .Get `src` }}" class="window-screenshot" />
+ </a>
+

--- a/layouts/shortcodes/workflow-screenshot.html
+++ b/layouts/shortcodes/workflow-screenshot.html
@@ -1,9 +1,9 @@
 {{ if .Page.Params.x2images }}
 <a href="{{ .Get `src`}}" class="blog-image_">
-      <img srcset="{{ .Get `src` }} 2x" class="sidework" />
+      <img srcset="{{ .Get `src` }} 2x" class="workflow-screenshot" />
 </a>
 {{ else }}
 <a href="{{ .Get `src`}}" class="blog-image_">
-      <img src="{{ .Get `src` }}" class="sidework" />
+      <img src="{{ .Get `src` }}" class="workflow-screenshot" />
 </a>
 {{ end }}

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1793,4 +1793,10 @@ img.window-screenshot, img.workflow-screenshot {
   margin-right: auto;
 }
 
-
+img {
+  image-rendering: -moz-crisp-edges;         /* Firefox */
+  image-rendering:   -o-crisp-edges;         /* Opera */
+  image-rendering: -webkit-optimize-contrast;/* Webkit (non-standard naming) */
+  image-rendering: crisp-edges;
+  -ms-interpolation-mode: nearest-neighbor;  /* IE (non-standard property) */
+}

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1774,18 +1774,18 @@ h2.docs-subtitle {
 }
 
 
-img.sidework {
+img.workflow-screenshot {
     /*float: left;*/
     /*margin-left: -70px;*/
 }
 
-img.tooltippic {
+img.window-screenshot {
     /*float: right;*/
     /*margin-right: -70px;*/
   max-height: 500px;
 }
 
-img.tooltippic, img.sidework {
+img.window-screenshot, img.workflow-screenshot {
     /*max-height: 60px;*/
     /*max-width: 60px;*/
   display: block;


### PR DESCRIPTION
This way it's clearer what each CSS class is supposed to be used for.

Originally these were named as such because we planned to put screenshots of workflows to the side, and window screenshots into tooltips. I think this idea is cool, but people aren't used to it, so you pay a 'learning curve' cost for each user that visits our blog.