### PR TITLE
Create alias for misspelled blog

### DIFF
--- a/content/blog/2020/2020-04-15-covid-19-part-3.md
+++ b/content/blog/2020/2020-04-15-covid-19-part-3.md
@@ -10,6 +10,7 @@ categories = ["covid-19", "visualization", "addons", "trends", "time"]
 shortExcerpt = "Inspection of Covid-19 time trends."
 longExcerpt = "Inspecting and comparing Covid-19 time trends, absolute and relative growth."
 x2images = true
+aliases = ["/blog/2020/2020-4-015-covid-19-part-3/"]
 +++
 
 So far, we've seen how to make [basic visualizations](https://orange.biolab.si/blog/2020/2020-04-02-covid-19-basic/) related to the corona virus and how to look at the [disease progression on the map](https://orange.biolab.si/blog/2020/2020-04-09-covid-19-part-2/). Be sure to check them out first, before delving into this one.


### PR DESCRIPTION
One blog was misspelled. Introduce alias to keep the old link valid, but create a new link that matches the previous posts.