### PR TITLE
Blog: fix link to categories containing space

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -17,7 +17,7 @@
             {{if gt $index 0 }}
             <span> | </span>
             {{end}}
-            <a href="/categories{{ . | relURL }}">{{ . }}</a>
+            <a href="/categories/{{ . | urlize }}">{{ . }}</a>
           </span>
           {{ end }}
         </div>


### PR DESCRIPTION
#### Issue

The link to categories that include space is not working. Hugo replaces spaces with `-`.

#### Fix

Using `urlize` method to correctly format categories in link.