### PR TITLE
Remove Features from the menu

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,11 +29,6 @@ unsafe = true
   blog = "blog"
 
 [menu]
-  [[menu.main]]
-    identifier = "features"
-    name = "Features"
-    url = "/#features"
-    weight = -130
 
   [[menu.main]]
     name = "Screenshots"


### PR DESCRIPTION
Our menu grew too much. We also talked about removing "Blog" in #167, but that one needs an additional link after latest stories.