### PR TITLE
Use orange3 stable branch to build widget catalog

### DIFF
--- a/scripts/build-widget-catalog.sh
+++ b/scripts/build-widget-catalog.sh
@@ -8,8 +8,8 @@ wget -qO- https://github.com/biolab/orange3/archive/stable.tar.gz | tar -zxf -
 mv orange3-stable orange3
 wget -qO- https://github.com/quasars/orange-spectroscopy/archive/master.tar.gz | tar -zxf -
 mv orange-spectroscopy-master orange-spectroscopy
-wget -qO- https://github.com/biolab/orange3-text/archive/master.tar.gz | tar -zxf -
-mv orange3-text-master orange3-text
+wget -qO- https://github.com/biolab/orange3-text/archive/stable.tar.gz | tar -zxf -
+mv orange3-text-stable orange3-text
 wget -qO- https://github.com/biolab/orange3-bioinformatics/archive/master.tar.gz | tar -zxf -
 mv orange3-bioinformatics-master orange3-bioinformatics
 wget -qO- https://github.com/biolab/orange3-single-cell/archive/master.tar.gz | tar -zxf -

--- a/scripts/build-widget-catalog.sh
+++ b/scripts/build-widget-catalog.sh
@@ -4,8 +4,8 @@ set -e
 
 mkdir external
 cd external
-wget -qO- https://github.com/biolab/orange3/archive/master.tar.gz | tar -zxf -
-mv orange3-master orange3
+wget -qO- https://github.com/biolab/orange3/archive/stable.tar.gz | tar -zxf -
+mv orange3-stable orange3
 wget -qO- https://github.com/quasars/orange-spectroscopy/archive/master.tar.gz | tar -zxf -
 mv orange-spectroscopy-master orange-spectroscopy
 wget -qO- https://github.com/biolab/orange3-text/archive/master.tar.gz | tar -zxf -


### PR DESCRIPTION
Fixes #233

I left most add-ons as they were, because we do not maintain consistent stable branches for all of them. We probably should.

I saw that orange3-text already has a well maintained stable branch, so I switched it over too.