### PR TITLE
Add Getting started link to Dev section

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -57,6 +57,7 @@
                             <ul class="links list-sitemap">
                                 <li><b><div class="sitemap-cat">Developers</div></b></li>
                                 <li><a class="sitemap-sub" target="_blank" href="https://github.com/biolab/orange3">GitHub</a></li>
+                                <li><a class="sitemap-sub" target="_blank" href="http://docs.biolab.si/3/development/">Getting Started</a></li>
                             </ul>
                         </div>
 


### PR DESCRIPTION
Partially resolves https://github.com/biolab/orange3/issues/5059.
Adds link to development documentation to the footer.