### PR TITLE
Update pip installation instructions

### DIFF
--- a/layouts/download/list.html
+++ b/layouts/download/list.html
@@ -139,9 +139,13 @@
                         as those provided by the conda-forge do not include webkit)</p>
 
                     <h3><a id="pip"></a>Pip</h3>
-                    <p>Orange can also be installed from the Python Package Index. You may need additional system
-                        packages provided by your distribution.</p>
+                    <p>Orange can also be installed from the Python Package Index. You may need additional system packages
+                       provided by your distribution. Installation into the system python environment often
+                       causes dependency conflicts. We thus recommend installing into a clean virtualenv
+                       environment. After installing Orange with pip, you will also need
+                       to install pyqt5 and pyqtwebengine.</p>
                     <pre><code>pip install orange3</code></pre>
+                    <pre><code>pip install pyqt5 pyqtwebengine</code></pre>
 
                     <h3>Installing from source</h3>
                     <p>Clone our repository from <a href="https://github.com/biolab/orange3">GitHub</a> or download


### PR DESCRIPTION
PyQt is now (or will be) a removed dependency: biolab/orange3#5566

This can be accepted independently: it should not break anything.