### PR TITLE
#219: Fix: FAQ clicking on a question scrolls to top

### DIFF
--- a/layouts/faq/list.html
+++ b/layouts/faq/list.html
@@ -17,7 +17,7 @@
                                 <div class="panel-heading accordion-toggle question-toggle collapsed" data-toggle="collapse"
                                     data-parent="#faqAccordion{{ $index }}" data-target="#question{{ $id }}">
                                     <h4 class="panel-title">
-                                        <a href="#" class="ing">{{ .question }}</a>
+                                        <a href="javascript:void(0);" class="ing">{{ .question }}</a>
                                     </h4>
                                 </div>
                                 <div id="question{{ $id }}" class="panel-collapse collapse" style="height: 0px;">


### PR DESCRIPTION
Fixes: #219 