### PR TITLE
Order workflows ascending by weight

### DIFF
--- a/layouts/partials/workflows.html
+++ b/layouts/partials/workflows.html
@@ -18,7 +18,7 @@
         <div id="search-results" style="display: none;">
         </div>
         <div id="post_nor">
-          {{ $paginator := .Paginate (where (where .Pages.ByWeight.Reverse "Type" "workflows") "IsPage" true) }}
+          {{ .Paginate (where (where .Pages.ByWeight "Type" "workflows") "IsPage" true) }}
           {{ range $index, $element := .Paginator.Pages }}
             <div class=" row">
                 {{ if eq (mod $index 2) 0 }}


### PR DESCRIPTION
Workflows are currently ordered descending by weight. It seems that they should be ordered ascending since more general workflows have lower weight