### PR TITLE
Deleted tags "Kaplan-Meyer" and "Time-to-event"

### DIFF
--- a/content/workflows/c-index-cross-validation.md
+++ b/content/workflows/c-index-cross-validation.md
@@ -5,7 +5,7 @@ type = "workflows"
 blog =  ""
 video = ""
 download = "730_c_index_cross_validation.ows"
-workflows = ["Survival Analysis", "Time-To-Event", "Cox Regression", "Concordance Index", "Cross Validation"]
+workflows = ["Survival Analysis", "Cox Regression", "Concordance Index", "Cross Validation"]
 weight = 730
 +++
 

--- a/content/workflows/cohort-construction-and-validation.md
+++ b/content/workflows/cohort-construction-and-validation.md
@@ -5,7 +5,7 @@ type = "workflows"
 blog =  ""
 video = ""
 download = "720_cohort_construction_and_validation.ows"
-workflows = ["Survival Analysis", "Time-To-Event", "Kaplan-Meier", "Cox Regression"]
+workflows = ["Survival Analysis", "Kaplan-Meier", "Cox Regression"]
 weight = 720
 +++
 

--- a/content/workflows/explore-subpopulations-with-distinct-risk-profiles.md
+++ b/content/workflows/explore-subpopulations-with-distinct-risk-profiles.md
@@ -5,7 +5,7 @@ type = "workflows"
 blog =  ""
 video = ""
 download = "740_hierarhical_clustering.ows"
-workflows = ["Survival Analysis", "Time-To-Event", "Kaplan-Meier", "Clustering", "Hierarchical Clustering", "Box Plot"]
+workflows = ["Survival Analysis", "Clustering", "Hierarchical Clustering", "Box Plot"]
 weight = 740
 +++
 

--- a/content/workflows/exploring-survival-features.md
+++ b/content/workflows/exploring-survival-features.md
@@ -5,7 +5,7 @@ type = "workflows"
 blog =  ""
 video = ""
 download = "710_survival_features.ows"
-workflows = ["Survival Analysis", "Time-To-Event", "Kaplan-Meier", "Cox Regression"]
+workflows = ["Survival Analysis", "Cox Regression"]
 weight = 710
 +++
 

--- a/content/workflows/survival-curve-estimation.md
+++ b/content/workflows/survival-curve-estimation.md
@@ -6,7 +6,7 @@ type = "workflows"
 blog =  ""
 video = ""
 download = "700_survival_curve_estimation.ows"
-workflows = ["Survival Analysis", "Time-To-Event", "Kaplan-Meier"]
+workflows = ["Survival Analysis"]
 weight = 700
 +++
 


### PR DESCRIPTION
The unnecessary tags "Kaplan-Meyer" and "Time-to-event" have been deleted from Workflows