### PR TITLE
Revert "Download binaries from Github"

### DIFF
--- a/layouts/download/list.html
+++ b/layouts/download/list.html
@@ -44,21 +44,19 @@
                 <div class="content">
                     <h2>Download the latest version for Windows</h2>
                     <a id="recommended-download-win" style="margin-top: 10px" class="btn btn-warning big-button-base"
-                        href="https://github.com/biolab/orange3/releases/download/{{$.Site.Params.version}}/Orange3-{{$.Site.Params.version}}-Win-Miniconda-x86_64.exe">
+                        href="https://download.biolab.si/download/files/Orange3-{{$.Site.Params.version}}-Miniconda-x86_64.exe">
                         Download Orange {{$.Site.Params.version}}
                     </a>
 
                     <h3><a id="standalone"></a>Standalone installer (default)</h3>
                     <a id="recommended-download"
-                        href="https://github.com/biolab/orange3/releases/download/{{$.Site.Params.version}}/Orange3-{{$.Site.Params.version}}-Win-Miniconda-x86_64.exe">
-                        Orange3-{{$.Site.Params.version}}-Win-Miniconda-x86_64.exe
+                        href="https://download.biolab.si/download/files/Orange3-{{$.Site.Params.version}}-Miniconda-x86_64.exe">Orange3-{{$.Site.Params.version}}-Miniconda-x86_64.exe
                         (64 bit)</a><br />
                     <p>Can be used without administrative priviledges.</p>
 
                     <h3><a id="portable"></a>Portable Orange</h3>
                     <a id="recommended-download"
-                        href="https://github.com/biolab/orange3/releases/download/{{$.Site.Params.version}}/Orange3-{{$.Site.Params.version}}-Win-Miniconda-x86_64.zip">
-                        Orange3-{{$.Site.Params.version}}-Win-Miniconda-x86_64.zip</a><br />
+                        href="https://download.biolab.si/download/files/Orange3-{{$.Site.Params.version}}.zip">Orange3-{{$.Site.Params.version}}.zip</a><br />
                     <p>No installation needed. Just extract the archive and open the shortcut in the extracted folder.</p>
 
                     <h3><a id="anaconda"></a>Anaconda</h3>
@@ -91,13 +89,13 @@
                 <div class="content">
                     <h2>Download the latest version for Mac</h2>
                     <a id="recommended-download-mac" style="margin-top: 10px" class="btn btn-warning big-button-base"
-                        href="https://github.com/biolab/orange3/releases/download/{{$.Site.Params.version}}/Orange3-{{$.Site.Params.version}}-Python3.8.8.dmg">
+                        href="https://download.biolab.si/download/files/Orange3-{{$.Site.Params.version}}-Python3.8.8.dmg">
                         Download Orange {{$.Site.Params.version}}
                     </a>
 
                     <h3><a id="standalone"></a>Bundle</h3>
                     <a id="recommended-download"
-                        href="https://github.com/biolab/orange3/releases/download/{{$.Site.Params.version}}/Orange3-{{$.Site.Params.version}}-Python3.8.8.dmg">Orange3-{{$.Site.Params.version}}-Python3.8.8.dmg</a><br />
+                        href="https://download.biolab.si/download/files/Orange3-{{$.Site.Params.version}}-Python3.8.8.dmg">Orange3-{{$.Site.Params.version}}-Python3.8.8.dmg</a><br />
                     <p>A universal bundle with everything packed in and ready to use.</p>
 
                     <h3><a id="anaconda"></a>Anaconda</h3>


### PR DESCRIPTION
Reverts biolab/orange-hugo#325.

When I tried downloading I saw an error from github explaining that egress is over the account limit. I'll revert.