### PR TITLE
Downloads - add instructions to install pyqt

### DIFF
--- a/layouts/download/list.html
+++ b/layouts/download/list.html
@@ -66,11 +66,13 @@
                         install packages from</p>
                     <pre><code>conda config --add channels conda-forge</code></pre>
                     <p>and run</p>
-                    <pre><code>conda install orange3</code></pre>
+                    <pre><code>conda install pyqt
+conda install orange3</code></pre>
 
                     <h3><a id="pip"></a>Pip</h3>
                     <p>Orange can also be installed from the Python Package Index:</p>
-                    <pre><code>pip install orange3</code></pre>
+                    <pre><code>pip install PyQt5 PyQtWebEngine
+pip install orange3</code></pre>
 
                     <h3>Installing add-ons</h3>
                     <p>Additional features can be added to Orange by installing add-ons. You can find add-on manager
@@ -105,11 +107,13 @@
                         install packages from</p>
                     <pre><code>conda config --add channels conda-forge</code></pre>
                     <p>and run</p>
-                    <pre><code>conda install orange3</code></pre>
+                    <pre><code>conda install pyqt
+conda install orange3</code></pre>
 
                     <h3><a id="pip"></a>Pip</h3>
                     <p>Orange can also be installed from the Python Package Index:</p>
-                    <pre><code>pip install orange3</code></pre>
+                    <pre><code>pip install PyQt5 PyQtWebEngine
+pip install orange3</code></pre>
 
                     <h3>Installing add-ons</h3>
                     <p>Additional features can be added to Orange by installing add-ons. You can find add-on manager in
@@ -135,12 +139,14 @@
                     <pre><code>conda config --add channels conda-forge
 conda config --set channel_priority strict</code></pre>
                     <p>and run</p>
-                    <pre><code>conda install orange3</code></pre>
+                    <pre><code>conda install pyqt
+conda install orange3</code></pre>
 
                     <h3><a id="pip"></a>Pip</h3>
                     <p>Orange can also be installed from the Python Package Index. You may need additional system
                         packages provided by your distribution.</p>
-                    <pre><code>pip install orange3</code></pre>
+                    <pre><code>pip install PyQt5 PyQtWebEngine
+pip install orange3</code></pre>
 
                     <h3>Installing from source</h3>
                     <p>Clone our repository from <a href="https://github.com/biolab/orange3">GitHub</a> or download


### PR DESCRIPTION
PyQt install magic is getting removed from Orange https://github.com/biolab/orange3/pull/6153

This PR adds the line with how to install pyqt in installing instructions.