### PR TITLE
Use PyQt6 to build widget catalog

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   build:
     name: Deploy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout master
         uses: actions/checkout@v3
@@ -26,12 +26,13 @@ jobs:
       - name: Install linux system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libegl1-mesa libxcb-shape0
+          sudo apt-get install -y glibc-tools  # required for catchsegv
+          sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libegl1-mesa libxcb-shape0 libxcb-cursor0
 
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Build widget catalog
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build widget catalog
         run: |
           pip install -U setuptools pip
-          pip install orange-canvas-core pyqt5==5.15.*
+          pip install orange-canvas-core pyqt6==6.5.*
           bash scripts/build-widget-catalog.sh
 
       - name: Setup Hugo

--- a/scripts/copy_docs.py
+++ b/scripts/copy_docs.py
@@ -58,8 +58,8 @@ def change_references(md_file, content, category, dest):
 
 
 from AnyQt.QtWidgets import QGraphicsScene
-from PyQt5.QtCore import QRectF, QSize, QSizeF, QPointF
-from PyQt5.QtGui import QColor, QPainter, QImage
+from AnyQt.QtCore import QRectF, QSize, QSizeF, QPointF
+from AnyQt.QtGui import QColor, QPainter, QImage
 
 from orangecanvas.registry import (
     WidgetDescription,

--- a/scripts/create_widget_catalog.py
+++ b/scripts/create_widget_catalog.py
@@ -24,9 +24,6 @@ class WidgetCatalog:
         self.categories = categories
         self.doc_dir = doc_dir
 
-        QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
-        QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps)
-        QApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
         self.app = QApplication([])
 
         print("Generating widget repository")


### PR DESCRIPTION
This options are not needed anymore because the script does not build png icons as it used to (some long time ago).