### PR TITLE
Blog Zivjo Orange - fix link and Slovenian incompatibility

### DIFF
--- a/content/blog/2023/2021-03-31-zivjo-orange.md
+++ b/content/blog/2023/2021-03-31-zivjo-orange.md
@@ -20,7 +20,7 @@ Among them, finally, Orange.
 
 Why? Primarily because Orange is already being used in higher education, while its use in younger population is often hindered by language barrier. This became particularly prononunced in the context of [Pumice](https://pumice.si) and related projects that aim to introduce AI as a tool for data exploration within different school subjects from K4 on.
 
-## Orange Slovenian
+## Orange in Slovenian
 
 It took over six months to translate Orange, starting with the development of Trubar, a general tool for translating modern Python code. Traditional translation tools, such as gettext, are not compatible with modern string interpolation and require modifications to the source code, which we wanted to avoid.
 

--- a/content/blog/2023/2021-03-31-zivjo-orange.md
+++ b/content/blog/2023/2021-03-31-zivjo-orange.md
@@ -20,8 +20,7 @@ Among them, finally, Orange.
 
 Why? Primarily because Orange is already being used in higher education, while its use in younger population is often hindered by language barrier. This became particularly prononunced in the context of [Pumice](https://pumice.si) and related projects that aim to introduce AI as a tool for data exploration within different school subjects from K4 on.
 
-## Orange in 
-ian
+## Orange Slovenian
 
 It took over six months to translate Orange, starting with the development of Trubar, a general tool for translating modern Python code. Traditional translation tools, such as gettext, are not compatible with modern string interpolation and require modifications to the source code, which we wanted to avoid.
 

--- a/content/blog/2023/2021-03-31-zivjo-orange.md
+++ b/content/blog/2023/2021-03-31-zivjo-orange.md
@@ -14,13 +14,14 @@ longExcerpt = "Orange speaks Slovenian!"
 {{< window-screenshot src="/blog_img/2023/2023-03-31-zemljevid.png" >}} 
 
 
-The Slovene language exhibits a complicated grammar, featuring three genders and four plural terms, along with a substantial amount of declensions and conjugations, (and unreasonable number of exceptions) that require all kinds of agreements between nouns, adjectives and verbs. It is mastered (unfortunatelly poorly, in too many cases) by some two million native speakers ... and a growing number of programs.
+The Slovenian language exhibits a complicated grammar, featuring three genders and four plural terms, along with a substantial amount of declensions and conjugations, (and unreasonable number of exceptions) that require all kinds of agreements between nouns, adjectives and verbs. It is mastered (unfortunatelly poorly, in too many cases) by some two million native speakers ... and a growing number of programs.
 
 Among them, finally, Orange.
 
-Why? Primarily because Orange is already being used in higher education, while its use in younger population is often hindered by language barrier. This became particularly prononunced in the context of (Pumice)[https://pumice.si] and related projects that aim to introduce AI as a tool for data exploration within different school subjects from K4 on.
+Why? Primarily because Orange is already being used in higher education, while its use in younger population is often hindered by language barrier. This became particularly prononunced in the context of [Pumice](https://pumice.si) and related projects that aim to introduce AI as a tool for data exploration within different school subjects from K4 on.
 
-## Orange in Slovenian
+## Orange in 
+ian
 
 It took over six months to translate Orange, starting with the development of Trubar, a general tool for translating modern Python code. Traditional translation tools, such as gettext, are not compatible with modern string interpolation and require modifications to the source code, which we wanted to avoid.
 


### PR DESCRIPTION
One link in the Zivjo Orange blog is not working due to a mistake in syntax. Also, through the blog, there is always used Slovenian (which is more correct according to [ISO](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes), except in one case. 

Fixing both issues. 