### PR TITLE
Migrate to Google Analytics 4 (GA4)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout master
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install linux system dependencies
         run: |
@@ -29,7 +29,7 @@ jobs:
           sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libegl1-mesa libxcb-shape0
 
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
 
@@ -39,15 +39,11 @@ jobs:
           pip install orange-canvas-core pyqt5==5.15
           bash scripts/build-widget-catalog.sh
 
-      - name: Build hugo page
-        run: |
-          wget https://github.com/gohugoio/hugo/releases/download/v0.88.1/hugo_extended_0.88.1_Linux-64bit.deb
-          sudo dpkg -i hugo*.deb
-          rm -rf public 2> /dev/null
-          rm *.deb
-          hugo --debug --path-warnings
-          touch public/.nojekyll
-
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.111.3'
+ 
       # Deploy to local repo
       - name: Deploy
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build widget catalog
         run: |
           pip install -U setuptools pip
-          pip install orange-canvas-core pyqt5==5.15
+          pip install orange-canvas-core pyqt5==5.15.*
           bash scripts/build-widget-catalog.sh
 
       - name: Setup Hugo

--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,7 @@ title = "Orange"
 disqusShortname = "orange-4"
 disablePathToLower = "True"
 disableKinds = ["taxonomyTerm"] #workflows and blog landing pages do not generate correctly without this because of the custom list.html pages
+googleAnalytics = "G-J6PJZF75EX"
 
 [params]
   version = "3.35.0"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -37,22 +37,12 @@
             .jsonly { display: none !important; }
         </style>
     </noscript>
-    <script type="text/javascript">
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    <!-- Google Analytics -->
+    {{- if not .Site.IsServer -}} <!-- disable while running localy -->
+        {{ template "_internal/google_analytics.html" . }}
+    {{- end -}}
 
-      ga('create', 'UA-528382-1', 'auto');
-      ga('require', 'linkid');
-      ga('send', 'pageview');
-
-
-    </script>
-
-
-<!-- Javascript -->
-
+    <!-- Javascript -->
     <script type="text/javascript" src="/plugins/jquery-1.10.2.min.js"></script>
     <script type="text/javascript" src="/plugins/jquery.form.js"></script>
     <script type="text/javascript" src="/plugins/bootstrap/js/bootstrap.min.js"></script>


### PR DESCRIPTION
Google Analytics universal token will stop working in July 2023

Moving to new GA4 property
Also:
- Slightly updated versions in GH Actions workflow
- Building Python with `peaceiris/actions-hugo@v2` instead of manual install
- Moved .nojekyll file to static instead of adding it on the build
- Updated PyQt5 version since the current one had an issue with hashes