### PR TITLE
CI - Read missing build step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,10 @@ jobs:
         uses: peaceiris/actions-hugo@v2
         with:
           hugo-version: '0.111.3'
+          extended: true
+
+      - name: Build
+        run: hugo --minify
  
       # Deploy to local repo
       - name: Deploy


### PR DESCRIPTION
In https://github.com/biolab/orange-hugo/pull/350 I accidentally skipped the `hugo build` step. I am reading it here. 